### PR TITLE
Removed the SECOND var

### DIFF
--- a/main.js
+++ b/main.js
@@ -27,7 +27,7 @@ const PADDLE_HEIGHT = 100;
 // Store the last level update in a variable
 var changedLevelAt = Date.now();
 // Setting the interval by which the speed will increase
-var timeInterval = 5 * 1000;
+var timeInterval = 5 * 1000; // in milliseconds
 // Speed added to the ball at each interval
 var speedAdded = 2;
 

--- a/main.js
+++ b/main.js
@@ -26,9 +26,8 @@ const PADDLE_HEIGHT = 100;
 
 // Store the last level update in a variable
 var changedLevelAt = Date.now();
-const SECOND = 1000;
 // Setting the interval by which the speed will increase
-var timeInterval = 5 * SECOND;
+var timeInterval = 5 * 1000;
 // Speed added to the ball at each interval
 var speedAdded = 2;
 


### PR DESCRIPTION
There's no need to make a variable called SECOND if you're only going to use it once. Also, it's pretty negligible, but the name of the variable is longer than the amount of characters in the value so performance wise its actually worse. As I said, it's pretty much negligible, but if you keep doing it, it adds up. 

It's fine if you don't accept the merge, just something to think about.